### PR TITLE
Implementing CommandLineRunner and adding test coverage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 	</properties>
 
 	<dependencies>
+		<!-- Spring -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
@@ -41,6 +42,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+
+		<!-- Utils -->
+		<dependency>
+			<groupId>commons-cli</groupId>
+			<artifactId>commons-cli</artifactId>
+			<version>1.4</version>
 		</dependency>
 
 		<!-- TDS -->

--- a/src/main/java/tds/testpackageconverter/ConvertToNewTestPackageCommandLineRunner.java
+++ b/src/main/java/tds/testpackageconverter/ConvertToNewTestPackageCommandLineRunner.java
@@ -50,6 +50,7 @@ public class ConvertToNewTestPackageCommandLineRunner implements CommandLineRunn
         final Option administrationFileOption = Option.builder(ADMINISTRATION_FLAG)
                 .argName("administration")
                 .hasArgs()
+                .longOpt("administration")
                 .desc("Administration file(s) to be converted")
                 .optionalArg(false)
                 .required(false)
@@ -57,6 +58,7 @@ public class ConvertToNewTestPackageCommandLineRunner implements CommandLineRunn
 
         final Option scoringFileOption = Option.builder(SCORING_FLAG)
                 .argName("scoring")
+                .longOpt("scoring")
                 .hasArg()
                 .desc("Scoring file(s) to be converted")
                 .optionalArg(false)
@@ -65,6 +67,7 @@ public class ConvertToNewTestPackageCommandLineRunner implements CommandLineRunn
 
         final Option diffFileOption = Option.builder(DIFF_FLAG)
                 .argName("diff")
+                .longOpt("diff")
                 .hasArg()
                 .desc("Diff file to be included in the conversion")
                 .optionalArg(false)
@@ -73,6 +76,7 @@ public class ConvertToNewTestPackageCommandLineRunner implements CommandLineRunn
 
         final Option zipFileOption = Option.builder(ZIP_FLAG)
                 .argName("zip")
+                .longOpt("zip")
                 .hasArg()
                 .desc("Zip file containing all test package parts")
                 .optionalArg(false)

--- a/src/main/java/tds/testpackageconverter/ConvertToNewTestPackageCommandLineRunner.java
+++ b/src/main/java/tds/testpackageconverter/ConvertToNewTestPackageCommandLineRunner.java
@@ -1,0 +1,171 @@
+package tds.testpackageconverter;
+
+import org.apache.commons.cli.*;
+import org.assertj.core.util.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+import tds.testpackageconverter.converter.TestPackageConverterService;
+
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class ConvertToNewTestPackageCommandLineRunner implements CommandLineRunner {
+    private static final Logger log = LoggerFactory.getLogger(ConvertToNewTestPackageCommandLineRunner.class);
+    private static final String CONVERT_TO_NEW_COMMAND = "convert-to-new";
+
+    private static final String ZIP_FLAG = "z";
+    private static final String ADMINISTRATION_FLAG = "a";
+    private static final String SCORING_FLAG = "s";
+    private static final String DIFF_FLAG = "d";
+
+    private final TestPackageConverterService service;
+
+    private Options options;
+    private CommandLineParser parser;
+    private CommandLine cmd;
+    private HelpFormatter formatter;
+
+    @Autowired
+    public ConvertToNewTestPackageCommandLineRunner(final TestPackageConverterService service) {
+        this.service = service;
+    }
+
+    /**
+     * Initiates the sub-command
+     */
+    @PostConstruct
+    public void init () {
+        options = new Options();
+        parser = new DefaultParser();
+        formatter = new HelpFormatter();
+
+        final Option administrationFileOption = Option.builder(ADMINISTRATION_FLAG)
+                .argName("administration")
+                .hasArgs()
+                .desc("Administration file(s) to be converted")
+                .optionalArg(false)
+                .required(false)
+                .build();
+
+        final Option scoringFileOption = Option.builder(SCORING_FLAG)
+                .argName("scoring")
+                .hasArg()
+                .desc("Scoring file(s) to be converted")
+                .optionalArg(false)
+                .required(false)
+                .build();
+
+        final Option diffFileOption = Option.builder(DIFF_FLAG)
+                .argName("diff")
+                .hasArg()
+                .desc("Diff file to be included in the conversion")
+                .optionalArg(false)
+                .required(false)
+                .build();
+
+        final Option zipFileOption = Option.builder(ZIP_FLAG)
+                .argName("zip")
+                .hasArg()
+                .desc("Zip file containing all test package parts")
+                .optionalArg(false)
+                .required(false)
+                .build();
+
+        options.addOption(administrationFileOption);
+        options.addOption(scoringFileOption);
+        options.addOption(diffFileOption);
+        options.addOption(zipFileOption);
+    }
+
+    @Override
+    public void run(final String... args) throws Exception {
+        if (args.length < 1) {
+            System.out.println("No arguments were provided to the test package converter. Aborting...");
+            printHelpAndExit();
+            return;
+        }
+
+        if (CONVERT_TO_NEW_COMMAND.equals(args[0])) {
+            parseAndHandleCommandErrors(args);
+
+            // Get the output test package filename
+            final String outputFilename = cmd.getArgList().get(1);
+
+            if (cmd.hasOption(ZIP_FLAG) && !cmd.getOptionValue(ZIP_FLAG).isEmpty()) {
+                convertTestPackageFromZipFile(outputFilename);
+            } else {
+                List<String> testSpecifications = new ArrayList<>();
+
+                if (cmd.hasOption(ADMINISTRATION_FLAG) && !cmd.getOptionValue(ADMINISTRATION_FLAG).isEmpty()) {
+                    System.out.println("Administration package(s): " + Arrays.toString(cmd.getOptionValues(ADMINISTRATION_FLAG)));
+
+                    testSpecifications.addAll(Lists.newArrayList(cmd.getOptionValues(ADMINISTRATION_FLAG)));
+                }
+
+                if (cmd.hasOption(SCORING_FLAG) && !cmd.getOptionValue(SCORING_FLAG).isEmpty()) {
+                    System.out.println("Scoring package: " + cmd.getOptionValue(SCORING_FLAG));
+                    testSpecifications.add(cmd.getOptionValue(SCORING_FLAG));
+                }
+
+                boolean success;
+
+                if (cmd.hasOption(DIFF_FLAG) && !cmd.getOptionValue(DIFF_FLAG).isEmpty()) {
+                    System.out.println("Diff package: " + cmd.getOptionValue(DIFF_FLAG));
+                    success = service.convertTestSpecifications(outputFilename, testSpecifications, cmd.getOptionValue(DIFF_FLAG));
+                } else {
+                    success = service.convertTestSpecifications(outputFilename, testSpecifications);
+                }
+
+                System.out.println(String.format("The test package '%s' was %s successfully created", outputFilename, success ? "" : "not"));
+            }
+        }
+    }
+
+    private void parseAndHandleCommandErrors(final String[] args) throws ParseException {
+        try {
+            cmd = parser.parse(options, args);
+
+            // We need two args - one to figure out what our action is, and a second to know the target filename
+            if (cmd.getArgList().size() < 2) {
+                printHelpAndExit();
+            }
+        } catch (UnrecognizedOptionException | MissingArgumentException e) {
+            printHelpAndExit();
+        }
+
+        if (cmd.hasOption(ZIP_FLAG)
+                && (cmd.hasOption(ADMINISTRATION_FLAG) || cmd.hasOption(DIFF_FLAG) || cmd.hasOption(SCORING_FLAG))) {
+            throw new IllegalArgumentException("If a zip file input is specified, no other additional inputs can be included.");
+        }
+
+        if ((cmd.hasOption(SCORING_FLAG) || cmd.hasOption(DIFF_FLAG)) && !cmd.hasOption(ADMINISTRATION_FLAG)) {
+            throw new MissingOptionException("A diff or scoring package cannot be provided as an input with no associated administration package");
+        }
+    }
+
+    private void convertTestPackageFromZipFile(final String outputFilename) {
+        System.out.println("Attempting to open and extract the zip file: " + outputFilename);
+
+        try {
+            service.extractAndConvertTestSpecifications(outputFilename, new File(cmd.getOptionValue(ZIP_FLAG)));
+            System.out.println("Finished converting the test package " + outputFilename);
+        } catch (FileNotFoundException e) {
+            System.out.println(String.format("ERROR: Zip file could not be found at path %s", cmd.getOptionValue(ZIP_FLAG)));
+        } catch (Exception e) {
+            System.out.println(String.format("ERROR: Error opening or unzipping the test package zip file at path %s", cmd.getOptionValue(ZIP_FLAG)));
+        }
+    }
+
+    private void printHelpAndExit() {
+        formatter.printHelp("Sample usage: convert-to-new <OUTPUT FILENAME> [OPTIONS] ", options);
+        System.exit(-1);
+    }
+}

--- a/src/main/java/tds/testpackageconverter/TestPackageConverterConsoleApplication.java
+++ b/src/main/java/tds/testpackageconverter/TestPackageConverterConsoleApplication.java
@@ -1,18 +1,16 @@
 package tds.testpackageconverter;
 
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+import tds.support.tool.testpackage.configuration.TestPackageObjectMapperConfiguration;
 
 @SpringBootApplication
-public class TestPackageConverterConsoleApplication implements CommandLineRunner {
+@Import(TestPackageObjectMapperConfiguration.class)
+public class TestPackageConverterConsoleApplication {
 
     public static void main(String[] args) throws Exception {
         SpringApplication.run(TestPackageConverterConsoleApplication.class, args);
     }
 
-    @Override
-    public void run(final String... args) throws Exception {
-
-    }
 }

--- a/src/main/java/tds/testpackageconverter/converter/TestPackageConverterService.java
+++ b/src/main/java/tds/testpackageconverter/converter/TestPackageConverterService.java
@@ -3,6 +3,7 @@ package tds.testpackageconverter.converter;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.List;
 
 /**
  * An interface for a service responsible for unzipping and deserializing test packages
@@ -11,9 +12,32 @@ public interface TestPackageConverterService {
     /**
      * @param testPackageName The name of the test package to convert to
      * @param file            The zip file containing legacy {@link tds.testpackage.legacy.model.Testspecification} files
-     *
-     * @return An XML blob of the converted {@link tds.testpackage.model.TestPackage}
+     * @return {@code true} if the file was created, {@code false} if the file already exists
      * @throws IOException If an error occurs while unzipping the test package zip file, or deserializing the content
      */
-    String extractAndConvertTestSpecifications(final String testPackageName, final File file) throws IOException, ParseException;
+    boolean extractAndConvertTestSpecifications(final String testPackageName, final File file) throws IOException, ParseException;
+
+    /**
+     * Converts one or more legacy test specifications to the new Test Package format
+     *
+     * @param testPackageName          A the name of the test package to produce
+     * @param adminAndScoringFileNames The filenames of the administration and scoring packages to convert
+     * @return {@code true} if this test package file was successfully created, {@code false} otherwise
+     * @throws IOException    If there is an error reading any of the test packages
+     * @throws ParseException If there is an error parsing any of the test packages
+     */
+    boolean convertTestSpecifications(String testPackageName, List<String> adminAndScoringFileNames) throws IOException, ParseException;
+
+    /**
+     * Converts one or more legacy test specifications to the new Test Package format
+     *
+     * @param testPackageName          A the name of the test package to produce
+     * @param adminAndScoringFileNames The filenames of the administration and scoring packages to convert
+     * @param diffFileName             The filename of the "diff" test package
+     * @return {@code true} if this test package file was successfully created, {@code false} otherwise
+     * @throws IOException    If there is an error reading any of the test packages
+     * @throws ParseException If there is an error parsing any of the test packages
+     */
+    boolean convertTestSpecifications(String testPackageName, List<String> adminAndScoringFileNames,
+                                      String diffFileName) throws IOException, ParseException;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  main:
+    web-application-type: none
+    banner-mode: 'off'
+
+logging.level.root: 'ERROR'

--- a/src/test/java/tds/testpackageconverter/converter/ConvertToNewTestPackageCommandLineRunnerTest.java
+++ b/src/test/java/tds/testpackageconverter/converter/ConvertToNewTestPackageCommandLineRunnerTest.java
@@ -1,0 +1,103 @@
+package tds.testpackageconverter.converter;
+
+import org.apache.commons.cli.MissingOptionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import tds.testpackageconverter.ConvertToNewTestPackageCommandLineRunner;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConvertToNewTestPackageCommandLineRunnerTest {
+    @Mock
+    private TestPackageConverterService mockConverterService;
+
+    private ConvertToNewTestPackageCommandLineRunner runner;
+
+    @Before
+    public void setup() {
+        runner = new ConvertToNewTestPackageCommandLineRunner(mockConverterService);
+        runner.init();
+    }
+
+    @Test
+    public void shouldConvertTestPackageSuccessfully() throws Exception {
+        runner.run("convert-to-new",
+                "-a", "test-package-admin1.xml", "test-package-admin2.xml",
+                "-s", "test-package-scoring.xml",
+                "-d", "test-package-diff.xml",
+                "converted-test-package.xml");
+
+        verify(mockConverterService, times(0)).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
+        verify(mockConverterService).convertTestSpecifications(eq("converted-test-package.xml"),
+                eq(Arrays.asList("test-package-admin1.xml", "test-package-admin2.xml", "test-package-scoring.xml")), eq("test-package-diff.xml"));
+    }
+
+    @Test
+    public void shouldConvertTestPackageSuccessfullyFilenameFirst() throws Exception {
+        runner.run("convert-to-new",
+                "converted-test-package.xml",
+                "-a", "test-package-admin1.xml", "test-package-admin2.xml",
+                "-s", "test-package-scoring.xml",
+                "-d", "test-package-diff.xml");
+
+        verify(mockConverterService, times(0)).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
+        verify(mockConverterService).convertTestSpecifications(eq("converted-test-package.xml"),
+                eq(Arrays.asList("test-package-admin1.xml", "test-package-admin2.xml", "test-package-scoring.xml")), eq("test-package-diff.xml"));
+    }
+
+    @Test
+    public void shouldConvertTestPackageSuccessfullyNoDiff() throws Exception {
+        runner.run("convert-to-new",
+                "-a", "test-package-admin1.xml", "test-package-admin2.xml",
+                "-s", "test-package-scoring.xml",
+                "converted-test-package.xml");
+
+        verify(mockConverterService, times(0)).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
+        verify(mockConverterService).convertTestSpecifications(eq("converted-test-package.xml"),
+                eq(Arrays.asList("test-package-admin1.xml", "test-package-admin2.xml", "test-package-scoring.xml")));
+    }
+
+    @Test
+    public void shouldConvertTestPackageSuccessfullyForZip() throws Exception {
+
+        runner.run("convert-to-new",
+                "-z", "test-package.zip",
+                "converted-test-package.xml");
+        verify(mockConverterService).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowForZipWithOtherInputs() throws Exception {
+        runner.run("convert-to-new",
+                "-a", "test-package-admin1.xml", "test-package-admin1.xml",
+                "-s", "test-package-scoring.xml",
+                "-d", "test-package-diff.xml",
+                "-z", "test-package.zip",
+                "converted-test-package.xml");
+    }
+
+    @Test(expected = MissingOptionException.class)
+    public void shouldThrowForNoAdminPackage() throws Exception {
+        runner.run("convert-to-new",
+                "-s", "input1", "input2",
+                "converted-test-package.xml");
+    }
+
+    @Test
+    public void shouldPrintHelpForScoringPackageWithMultipleInputs() throws Exception {
+        runner.run("convert-to-new",
+                "converted-test-package.xml",
+                "-a", "admin1",
+                "-s", "input1", "input2");
+    }
+}

--- a/src/test/java/tds/testpackageconverter/converter/ConvertToNewTestPackageCommandLineRunnerTest.java
+++ b/src/test/java/tds/testpackageconverter/converter/ConvertToNewTestPackageCommandLineRunnerTest.java
@@ -56,6 +56,19 @@ public class ConvertToNewTestPackageCommandLineRunnerTest {
     }
 
     @Test
+    public void shouldConvertTestPackageSuccessfullyVerbose() throws Exception {
+        runner.run("convert-to-new",
+                "converted-test-package.xml",
+                "--administration", "test-package-admin1.xml", "test-package-admin2.xml",
+                "--scoring", "test-package-scoring.xml",
+                "--diff", "test-package-diff.xml");
+
+        verify(mockConverterService, times(0)).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
+        verify(mockConverterService).convertTestSpecifications(eq("converted-test-package.xml"),
+                eq(Arrays.asList("test-package-admin1.xml", "test-package-admin2.xml", "test-package-scoring.xml")), eq("test-package-diff.xml"));
+    }
+
+    @Test
     public void shouldConvertTestPackageSuccessfullyNoDiff() throws Exception {
         runner.run("convert-to-new",
                 "-a", "test-package-admin1.xml", "test-package-admin2.xml",
@@ -72,6 +85,15 @@ public class ConvertToNewTestPackageCommandLineRunnerTest {
 
         runner.run("convert-to-new",
                 "-z", "test-package.zip",
+                "converted-test-package.xml");
+        verify(mockConverterService).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
+    }
+
+    @Test
+    public void shouldConvertTestPackageSuccessfullyForZipVerbose() throws Exception {
+
+        runner.run("convert-to-new",
+                "--zip", "test-package.zip",
                 "converted-test-package.xml");
         verify(mockConverterService).extractAndConvertTestSpecifications(eq("converted-test-package.xml"), isA(File.class));
     }

--- a/src/test/java/tds/testpackageconverter/converter/impl/TestPackageServiceImplTest.java
+++ b/src/test/java/tds/testpackageconverter/converter/impl/TestPackageServiceImplTest.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.ParseException;
+import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
@@ -49,26 +50,43 @@ public class TestPackageServiceImplTest extends TestPackageBaseTest {
     }
 
     @Test
-    public void shouldConvertTestPackageSuccessfully() throws IOException, ParseException {
-        final String testPackageName = "A Test Package";
+    public void shouldConvertTestPackageZipSuccessfully() throws IOException, ParseException {
+        final String testPackageName = "converted-test-package.xml";
         when(mockMapper.readValue(isA(InputStream.class), eq(Testspecification.class)))
                 .thenReturn(mockPerfAdminLegacyTestPackage);
-        final String result = service.extractAndConvertTestSpecifications(testPackageName, mockFile);
-        assertThat(result).isNotNull();
-        assertThat(result).isEqualTo("testpackage");
+        final boolean result = service.extractAndConvertTestSpecifications(testPackageName, mockFile);
+        assertThat(result).isTrue();
         verify(mockMapper, times(2)).readValue(isA(InputStream.class), eq(Testspecification.class));
+    }
+
+    @Test
+    public void shouldConvertTestPackageFilesSuccessfully() throws IOException, ParseException {
+        final String testPackageName = "converted-test-package.xml";
+        final String file1 = "src/test/resources/(SBAC_PT)SBAC-IRP-CAT-MATH-11-Summer-2015-2016.xml";
+        final String file2 = "src/test/resources/(SBAC_PT)SBAC-IRP-MATH-11-COMBINED-Summer-2015-2016.xml";
+        final String file3 = "src/test/resources/(SBAC_PT)SBAC-IRP-Perf-MATH-11-Summer-2015-2016.xml";
+
+        when(mockMapper.readValue(new File(file1), Testspecification.class)).thenReturn(mockCATAdminLegacyTestPackage);
+        when(mockMapper.readValue(new File(file2), Testspecification.class)).thenReturn(mockCombinedScoringPackage);
+        when(mockMapper.readValue(new File(file3), Testspecification.class)).thenReturn(mockPerfAdminLegacyTestPackage);
+
+        service.convertTestSpecifications(testPackageName, Arrays.asList(file1, file2, file3));
+
+        verify(mockMapper).readValue(new File(file1), Testspecification.class);
+        verify(mockMapper).readValue(new File(file2), Testspecification.class);
+        verify(mockMapper).readValue(new File(file3), Testspecification.class);
     }
 
     @Test(expected = IOException.class)
     public void shouldThrowIOExceptionIfInputIsNotAZip() throws IOException, ParseException {
-        final String testPackageName = "A Test Package";
+        final String testPackageName = "converted-test-package.xml";
         File file = new File("src/test/resources/(SBAC_PT)SBAC-IRP-Perf-MATH-11-Summer-2015-2016.xml");
         service.extractAndConvertTestSpecifications(testPackageName, file);
     }
 
     @Test(expected = IOException.class)
     public void shouldThrowIOExceptionIfZipContainsNoXmlFiles() throws IOException, ParseException {
-        final String testPackageName = "A Test Package";
+        final String testPackageName = "converted-test-package.xml";
         File file = new File("src/test/resources/textfile.zip");
         service.extractAndConvertTestSpecifications(testPackageName, file);
     };

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,2 @@
+spring.main.web-environment=false
+spring.main.banner-mode=off


### PR DESCRIPTION
Hooking up CLI to existing old -> new converter code. 

A user can either provide a zip file (using the -z flag) or multiple administration (and optionally a diff or scoring package) as individual inputs (using -a, -d, and -s flags)