### PR TITLE
Fix misleading error message

### DIFF
--- a/src/main/java/tds/testpackageconverter/ConvertToNewTestPackageCommandLineRunner.java
+++ b/src/main/java/tds/testpackageconverter/ConvertToNewTestPackageCommandLineRunner.java
@@ -178,15 +178,9 @@ public class ConvertToNewTestPackageCommandLineRunner implements CommandLineRunn
 
         try {
             service.extractAndConvertTestSpecifications(outputFilename, new File(cmd.getOptionValue(ZIP_FLAG)));
-            System.out.println("Finished converting the test package " + outputFilename);
-        } catch (FileNotFoundException e) {
-            System.out.println(String.format("ERROR: Zip file could not be found at path %s", cmd.getOptionValue(ZIP_FLAG)));
-
-            if (cmd.hasOption(VERBOSE_FLAG)) {
-                e.printStackTrace();
-            }
+            System.out.println("Finished converting the test package " + outputFilename);        
         } catch (Exception e) {
-            System.out.println(String.format("ERROR: Error opening or unzipping the test package zip file at path %s", cmd.getOptionValue(ZIP_FLAG)));
+            System.out.println(e.getMessage());
 
             if (cmd.hasOption(VERBOSE_FLAG)) {
                 e.printStackTrace();

--- a/src/main/java/tds/testpackageconverter/converter/impl/TestPackageConverterServiceImpl.java
+++ b/src/main/java/tds/testpackageconverter/converter/impl/TestPackageConverterServiceImpl.java
@@ -42,7 +42,12 @@ public class TestPackageConverterServiceImpl implements TestPackageConverterServ
 
     @Override
     public void extractAndConvertTestSpecifications(final String testPackageName, final File file) throws IOException, ParseException {
-        ZipFile zipFile = new ZipFile(file);
+        ZipFile zipFile;
+        try {
+            zipFile = new ZipFile(file);
+        } catch(IOException e) {
+            throw new IOException(String.format("ERROR: Processing input test specification zip file: %s\n%s", file.getAbsolutePath(), e.getMessage()), e);
+        }
         File convertedTestPackageFile = new File(testPackageName);
 
         List<Testspecification> specifications = zipFile.stream()
@@ -65,7 +70,11 @@ public class TestPackageConverterServiceImpl implements TestPackageConverterServ
                 ? TestPackageMapper.toNew(testPackageName, specifications, diff.get())
                 : TestPackageMapper.toNew(testPackageName, specifications);
 
-        legacyXmlMapper.writeValue(convertedTestPackageFile, testPackage);
+        try {
+            legacyXmlMapper.writeValue(convertedTestPackageFile, testPackage);
+        } catch (IOException  e) {
+            throw new IOException(String.format("ERROR: Processing converted test specification output file: %s\n%s", convertedTestPackageFile.getAbsolutePath(), e.getMessage()), e);
+        }
 
         convertedTestPackageFile.createNewFile();
     }


### PR DESCRIPTION
Fix misleading error message when converting a file that has an invalid folder name.

When an error occurs while writing the output file, the input filename is displayed in the error message.