### PR TITLE
Preventing duplicate stimuli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<support-tool-client.version>4.1.12</support-tool-client.version>
+		<support-tool-client.version>4.1.16</support-tool-client.version>
 		<tds-common.version>5.0.4</tds-common.version>
 
 		<maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>

--- a/src/main/java/tds/testpackageconverter/converter/mappers/LegacyAdministrationTestPackageItemPoolMapper.java
+++ b/src/main/java/tds/testpackageconverter/converter/mappers/LegacyAdministrationTestPackageItemPoolMapper.java
@@ -7,9 +7,9 @@ import tds.testpackageconverter.utils.TestPackageUtils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class LegacyAdministrationTestPackageItemPoolMapper {
@@ -21,7 +21,7 @@ public class LegacyAdministrationTestPackageItemPoolMapper {
     }
 
     private static List<Passage> mapPassages(final TestPackage testPackage, final Assessment assessment) {
-        final List<Stimulus> stimuli = assessment.getSegments().stream()
+        final Set<Stimulus> stimuli = assessment.getSegments().stream()
                 .flatMap(segment -> {
                     if (segment.getAlgorithmType().equalsIgnoreCase(Algorithm.FIXED_FORM.getType())) {
                         return segment.segmentForms().stream()
@@ -35,7 +35,7 @@ public class LegacyAdministrationTestPackageItemPoolMapper {
                                 .map(itemGroup -> itemGroup.getStimulus().get());
                     }
                 })
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
 
         return stimuli.stream().map(stimulus -> {
             final Passage passage = new Passage();


### PR DESCRIPTION
Implemented `equals()` on `Stimulus` in Support Tool client to prevent duplicate stimulus elements when there are items in different tests that reference the same stim.